### PR TITLE
Add database migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <com.auth0.java-jwt.version>3.19.2</com.auth0.java-jwt.version>
         <org.springframework.cloud.spring-cloud-starter-openfeign.version>3.1.4</org.springframework.cloud.spring-cloud-starter-openfeign.version>
         <plugin.prettier.goal>write</plugin.prettier.goal>
+        <liquibase.version>4.19.0</liquibase.version>
     </properties>
     <dependencies>
         <dependency>
@@ -67,6 +68,11 @@
             <groupId>de.uni-stuttgart.gamify-it</groupId>
             <artifactId>authentification-validator</artifactId>
             <version>${authentification-validator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>${liquibase.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ server.port=8000
 overworld.url=http://localhost/overworld/api/v1
 keycloak.issuer=http://localhost/keycloak/realms/Gamify-IT
 keycloak.url=http://localhost/keycloak/realms/Gamify-IT
+
+spring.liquibase.change-log=classpath:db/changelog-root.xml
+

--- a/src/main/resources/db/changelog-root.xml
+++ b/src/main/resources/db/changelog-root.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd
+      http://www.liquibase.org/xml/ns/pro
+      http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd">
+<includeAll path="db/changelog/"/><!-- Automatically queries all files in this directory in lexical order -->
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-1.0.sql
+++ b/src/main/resources/db/changelog/changelog-1.0.sql
@@ -1,0 +1,59 @@
+-- liquibase formatted sql
+
+-- changeset leon:change1-1
+CREATE TABLE "configuration_codes" ("configuration_id" UUID NOT NULL, "codes_id" UUID NOT NULL, CONSTRAINT "configuration_codes_pkey" PRIMARY KEY ("configuration_id", "codes_id"));
+
+-- changeset leon:change1-2
+CREATE TABLE "code_words" ("code_id" UUID NOT NULL, "words_id" UUID NOT NULL);
+
+-- changeset leon:change1-3
+CREATE TABLE "solution_bugs" ("solution_id" UUID NOT NULL, "bugs_id" UUID NOT NULL, CONSTRAINT "solution_bugs_pkey" PRIMARY KEY ("solution_id", "bugs_id"));
+
+-- changeset leon:change1-4
+ALTER TABLE "configuration_codes" ADD CONSTRAINT "uk_ojb48o72tahwues3uvlrsm3i9" UNIQUE ("codes_id");
+
+-- changeset leon:change1-5
+ALTER TABLE "code_words" ADD CONSTRAINT "uk_rnftyyvtm3o21whfbxb8ys7dt" UNIQUE ("words_id");
+
+-- changeset leon:change1-6
+ALTER TABLE "solution_bugs" ADD CONSTRAINT "uk_t6949bp8xqli9wp3yge2ki1g0" UNIQUE ("bugs_id");
+
+-- changeset leon:change1-7
+CREATE TABLE "bug" ("id" UUID NOT NULL, "correct_value" VARCHAR(255), "error_type" INTEGER, "word_id" UUID, CONSTRAINT "bug_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-8
+CREATE TABLE "code" ("id" UUID NOT NULL, CONSTRAINT "code_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-9
+CREATE TABLE "configuration" ("id" UUID NOT NULL, CONSTRAINT "configuration_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-10
+CREATE TABLE "solution" ("id" UUID NOT NULL, "code_id" UUID, CONSTRAINT "solution_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-11
+CREATE TABLE "word" ("id" UUID NOT NULL, "word" VARCHAR(255), CONSTRAINT "word_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-12
+ALTER TABLE "solution" ADD CONSTRAINT "fk20ltujstgdyb0ecmkjg2r9hyp" FOREIGN KEY ("code_id") REFERENCES "code" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-13
+ALTER TABLE "configuration_codes" ADD CONSTRAINT "fk2ukcuug7ve2764uau9s6ow7kh" FOREIGN KEY ("codes_id") REFERENCES "code" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-14
+ALTER TABLE "bug" ADD CONSTRAINT "fkdkqevhvo9ou92q6bvqrtbgt1h" FOREIGN KEY ("word_id") REFERENCES "word" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-15
+ALTER TABLE "configuration_codes" ADD CONSTRAINT "fkeu1jbi9ygfualavyrmban6frf" FOREIGN KEY ("configuration_id") REFERENCES "configuration" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-16
+ALTER TABLE "solution_bugs" ADD CONSTRAINT "fki2bngjltgjgspthdfr950lqx" FOREIGN KEY ("solution_id") REFERENCES "solution" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-17
+ALTER TABLE "code_words" ADD CONSTRAINT "fkju0l4dvy0qamwtdj5mipxt9x" FOREIGN KEY ("words_id") REFERENCES "word" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-18
+ALTER TABLE "code_words" ADD CONSTRAINT "fkkix1vyriqpnnll47eei8s452v" FOREIGN KEY ("code_id") REFERENCES "code" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-19
+ALTER TABLE "solution_bugs" ADD CONSTRAINT "fko8ankki1ifj8fvd1s64i0qvip" FOREIGN KEY ("bugs_id") REFERENCES "bug" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+


### PR DESCRIPTION
In the future, any PR that changes stored data must also adapt the corresponding changelog under `src/main/resources/db/changelog/changelog-<version>.sql`.
New versions should also use a new changelog instead of appending to an old one.
For details on how to keep the changelog up to date, consult the docs.
Part of Gamify-IT/issues#439.
Replaces #8.